### PR TITLE
Slider not reset properly

### DIFF
--- a/src/Practice.elm
+++ b/src/Practice.elm
@@ -32,18 +32,19 @@ type alias Experiment =
 
 emptyExperiment : Int -> Experiment
 emptyExperiment x =
-    { samples = randomize x [0..19]
-    , correct = randomize x correctAnswers
-    , rates = repeat 20 50
-    , repeats = repeat 20 0
-    , sound = { soundId = 0, playSound = True }
-    , i = 0
-    , firstPhase = 10
-    , error = False
-    , endEarly = False
-    , done = False
-    , explanation = True
-    }
+    let samples = randomize x [0..19]
+    in { samples = samples
+       , correct = randomize x correctAnswers
+       , rates = repeat 20 50
+       , repeats = repeat 20 0
+       , sound = { soundId = samples !! 0, playSound = True }
+       , i = 0
+       , firstPhase = 10
+       , error = False
+       , endEarly = False
+       , done = False
+       , explanation = True
+       }
 
 lastFragment : Experiment -> Bool
 lastFragment exp = exp.i == (length exp.samples - 1)

--- a/src/Presti.elm
+++ b/src/Presti.elm
@@ -275,7 +275,7 @@ port playSound = playSoundSignal
 port donePlaying : Signal Bool
 
 port refreshFoundation : Signal Float
-port refreshFoundation = every second
+port refreshFoundation = every (50 * millisecond)
 
 port sliderValue : Signal Int
 


### PR DESCRIPTION
Because foundation was continually sending slider value updates, this
could cause race conditions where a value was updated, but immediately
overwritten by a slider update sent just before the value change. This
caused the effect of the slider 'being stuck in place'.

This is fixed by keeping the previously sent value in memory and only
sending changes if the value actually changed.

Also updated the foundation update signal, to have a smoother UX

Closes #39
